### PR TITLE
bump deps

### DIFF
--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -4,6 +4,8 @@ version := "1.0.0"
 
 scalaVersion in ThisBuild := "2.12.6"
 
+val derivingVersion = "1.0.0-RC1"
+
 /* Settings common to each sub project */
 val common = Seq(
   scalacOptions ++= Seq(
@@ -20,17 +22,17 @@ val common = Seq(
   resolvers += Resolver.sonatypeRepo("snapshots"),
 
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
-  addCompilerPlugin("com.fommil" %% "deriving-plugin" % "0.13.1"),
+  addCompilerPlugin("com.fommil" %% "deriving-plugin" % derivingVersion),
   addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4"),
 
   libraryDependencies ++= Seq(
-    "com.fommil"    %% "deriving-macro"  % "0.13.1",
-    "com.fommil"    %% "scalaz-deriving" % "0.13.1",
+    "com.fommil"    %% "deriving-macro"  % derivingVersion,
+    "com.fommil"    %% "scalaz-deriving" % derivingVersion,
     "org.typelevel" %% "cats-core"       % "1.1.0",
     "org.typelevel" %% "cats-effect"     % "1.0.0-RC2",
     "org.typelevel" %% "kittens"         % "1.0.0",
-    "org.scalaz"    %% "scalaz-core"     % "7.2.24",
-    "org.scalaz"    %% "scalaz-ioeffect" % "2.3.0"
+    "org.scalaz"    %% "scalaz-core"     % "7.2.25",
+    "org.scalaz"    %% "scalaz-ioeffect" % "2.10.1"
   )
 )
 

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -45,9 +45,9 @@ lazy val lib = project.in(file(".")).settings(common)
  */
 lazy val bench = project.in(file("bench")).settings(common).dependsOn(lib).enablePlugins(JmhPlugin).settings(
   // bench/jmh:run -i 15 -wi 15 -f1 -t10 .*EqualBench.equalDiffScalaz*
-  javaOptions in (Jmh, run) ++= scala.util.Properties.envOrNone("YOURKIT_AGENT").map { name =>
-    val agent = file(name)
-    require(agent.exists(), s"Yourkit agent specified ($agent) does not exist")
-    Seq(s"-agentpath:${agent.getCanonicalPath}=quiet")
-  }.getOrElse(Nil)
+  // javaOptions in (Jmh, run) ++= scala.util.Properties.envOrNone("YOURKIT_AGENT").map { name =>
+  //   val agent = file(name)
+  //   require(agent.exists(), s"Yourkit agent specified ($agent) does not exist")
+  //   Seq(s"-agentpath:${agent.getCanonicalPath}=quiet")
+  // }.getOrElse(Nil)
 )

--- a/scala/project/build.properties
+++ b/scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.4
+sbt.version=1.1.6


### PR DESCRIPTION
```
[info] Benchmark                          Mode  Cnt       Score      Error  Units
[info] EqualBench.equalDiffClassCats      avgt   15   97766.777 ± 1177.263  ns/op
[info] EqualBench.equalDiffClassScalaz    avgt   15    3847.684 ±   32.298  ns/op
[info] EqualBench.equalDiffClassVanilla   avgt   15    2928.156 ±   32.670  ns/op
[info] EqualBench.equalDiffIntCats        avgt   15    7727.001 ±  116.271  ns/op
[info] EqualBench.equalDiffIntScalaz      avgt   15   11882.071 ±  129.923  ns/op
[info] EqualBench.equalDiffIntVanilla     avgt   15   10164.713 ±  150.149  ns/op
[info] EqualBench.equalSameClassCats      avgt   15       5.758 ±    0.076  ns/op
[info] EqualBench.equalSameClassScalaz    avgt   15      27.659 ±    0.198  ns/op
[info] EqualBench.equalSameClassVanilla   avgt   15       5.131 ±    0.043  ns/op
[info] EqualBench.equalSameIntCats        avgt   15       5.145 ±    0.053  ns/op
[info] EqualBench.equalSameIntScalaz      avgt   15      27.654 ±    0.199  ns/op
[info] EqualBench.equalSameIntVanilla     avgt   15       5.101 ±    0.037  ns/op
[info] EqualBench.equalWhileClassCats     avgt   15   88214.503 ±  679.495  ns/op
[info] EqualBench.equalWhileClassScalaz   avgt   15  791298.323 ± 5002.390  ns/op
[info] EqualBench.equalWhileClassVanilla  avgt   15   10346.874 ±  277.580  ns/op
[info] EqualBench.equalWhileIntCats       avgt   15     413.640 ±    2.860  ns/op
[info] EqualBench.equalWhileIntScalaz     avgt   15    9649.178 ±  148.105  ns/op
[info] EqualBench.equalWhileIntVanilla    avgt   15     416.650 ±    8.636  ns/op
```